### PR TITLE
fix(ci): iil-platform-context tote git-subdir → PyPI (Audit-F4)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ gunicorn>=22
 
 # IIL Platform Packages
 iil-learnfw[api] @ git+https://github.com/achimdehnert/learnfw.git@main
-iil-platform-context @ git+https://github.com/achimdehnert/platform.git#subdirectory=packages/platform-context
+iil-platform-context>=0.7.0,<1
 
 # Infrastructure
 celery[redis]>=5.3


### PR DESCRIPTION
Tote `git+.../platform.git#subdirectory=packages/platform-context` (Verzeichnis existiert nicht) → `iil-platform-context>=0.7.0,<1` (PyPI). Fixt Test-Gate-Install-Abbruch (F4 Hebel-1). CI soll regulär grünen. 🤖 Generated with [Claude Code](https://claude.com/claude-code)