### PR TITLE
ci(deploy): adopt #451 import-smoke gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,4 +47,10 @@ jobs:
       image_tag_override: ${{ inputs.image_tag_override || '' }}
       target_environment: ${{ inputs.target_environment || 'production' }}
       notify_discord: true
+      # Import-Smoke-Gate (platform #451): lädt Django + triggert Celery-Task-
+      # Autodiscovery + Root-URLConf im frisch gebauten Image. Fängt Import-
+      # Contract-Drift VOR dem Deploy — sonst erst zur Laufzeit als Worker-
+      # Crash-Loop sichtbar. DB-frei (nur Imports; DB-Connections sind lazy).
+      # learn-hub liest SECRET_KEY aus DJANGO_SECRET_KEY (base.py), nicht SECRET_KEY.
+      import_smoke: 'DJANGO_SECRET_KEY=ci-smoke DJANGO_SETTINGS_MODULE=config.settings.test python -c "import django; django.setup(); from config.celery import app; app.loader.import_default_modules(); from django.urls import get_resolver; get_resolver().url_patterns"'
     secrets: inherit


### PR DESCRIPTION
Adopts platform's opt-in `import_smoke` input (platform #451) into learn-hub's `_deploy-unified.yml@main` call. Template: achimdehnert/cad-hub#20.

## What the smoke does

Runs inside the freshly built image in the `build` job, before deploy. Non-zero exit fails the build → deploy is skipped.

```
DJANGO_SECRET_KEY=ci-smoke DJANGO_SETTINGS_MODULE=config.settings.test \
python -c "import django; django.setup(); \
from config.celery import app; app.loader.import_default_modules(); \
from django.urls import get_resolver; get_resolver().url_patterns"
```

It exercises three import contracts:
1. `django.setup()` — loads all INSTALLED_APPS (admin, DRF, `iil_learnfw`, `apps.core`, `apps.learning`).
2. `app.loader.import_default_modules()` — Celery task autodiscovery; catches `tasks.py` import drift that would otherwise only surface as a worker crash-loop at runtime.
3. `get_resolver().url_patterns` — forces full resolution of `config.urls` + all included urlconfs.

## Why DB-free

- `django.setup()`, task-module imports, and URL resolution are pure import/config work; Django DB connections are lazy, so none of these open a connection.
- Settings module is `config.settings.test`, which seeds `DJANGO_SECRET_KEY` and `ASSESSMENT_IP_HASH_SALT` via `os.environ.setdefault` (the `DJANGO_SECRET_KEY=ci-smoke` prefix is the explicit, template-aligned value).

## Env var note

learn-hub's `config/settings/base.py` reads `SECRET_KEY = config("DJANGO_SECRET_KEY")` (not `SECRET_KEY`), so the smoke uses `DJANGO_SECRET_KEY=ci-smoke` — diverging from the cad-hub template, which uses `SECRET_KEY`.

## Verification

Built a throwaway venv with the runtime deps (local `iil-learnfw` editable + platform-context, celery, DRF, etc.) and ran the exact command against current `main`:

```
SMOKE OK   (exit 0)
```

No latent import bug on main; the gate is green today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)