### PR TITLE
ci(deploy): pin deploy job to prod-server runner (#461)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,11 @@ jobs:
       image_tag_override: ${{ inputs.image_tag_override || '' }}
       target_environment: ${{ inputs.target_environment || 'production' }}
       notify_discord: true
+      # Deploy-Runner pinnen (platform #461): generisches `self-hosted` kann
+      # non-deterministisch auf dev-hetzner statt prod-server landen (Root-Cause
+      # cad-hub#21). learn-hub deployt nach /opt/learn-hub auf dem Prod-Host
+      # (https://learn.iil.pet) → fest auf den `prod-server`-Runner pinnen.
+      deploy_runs_on: "prod-server"
       # Import-Smoke-Gate (platform #451): lädt Django + triggert Celery-Task-
       # Autodiscovery + Root-URLConf im frisch gebauten Image. Fängt Import-
       # Contract-Drift VOR dem Deploy — sonst erst zur Laufzeit als Worker-


### PR DESCRIPTION
Pins the host-bound deploy job to the **prod-server** runner via the \`deploy_runs_on\` input added in platform #461.

## Why
\`_deploy-unified.yml@main\` runs the deploy job on a generic \`self-hosted\` label, which can non-deterministically land on **dev-hetzner** instead of **prod-server** (root cause: cad-hub#21). The deploy does an atomic-sync to \`/opt/<app>\` on the target host, so it MUST run on the correct host.

## Why prod-server is correct here (verified)
- \`app_path: /opt/learn-hub\`, \`health_check_url: https://learn.iil.pet/healthz/\`, \`target_environment: production\` → learn-hub deploys to the **prod host**.
- The single self-hosted runner registered on this repo is named **prod-server** with the unique label \`prod-server\` (labels: self-hosted, Linux, X64, prod-server).
- Latest main Deploy run is **SUCCESS** — this change only makes targeting deterministic, it does not change the host.

## Change
\`\`\`yaml
deploy_runs_on: "prod-server"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)