### PR TITLE
chore(ci): bump shared-ci → v1.0.6 — exponiert `ci / gate` (ADR-242 Wave 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   ci:
     name: "CI"
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@test/wave3-aifw-tenacity-canary
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.6
     with:
       python_version: "3.12"
       coverage_threshold: 80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   ci:
     name: "CI"
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.0
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.6
     with:
       python_version: "3.12"
       coverage_threshold: 80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   ci:
     name: "CI"
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.6
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@test/wave3-aifw-tenacity-canary
     with:
       python_version: "3.12"
       coverage_threshold: 80


### PR DESCRIPTION
## Warum

ADR-242 Branch-Protection braucht als required check den **stabilen Aggregat-Job `ci / gate`**. learn-hubs PR-CI (`ci.yml`) ruft den shared-ci-Reusable bereits — aber auf **`@v1.0.0`**, das den `gate`-Job noch nicht kennt. Dieser Einzeiler-Bump auf **`@v1.0.6`** exponiert `ci / gate` auf `pull_request` und macht learn-hub damit **Wave-3-fähig**.

## Sicherheit des Bumps (v1.0.2→v1.0.6 vorab gediffed)

- **Tag-Integrität:** `v1.0.6 == iilgmbh/shared-ci@main` (0 Zeilen Drift).
- **Production-Beweis:** `@v1.0.6` läuft bereits **live grün** auf trading-hub (Wave 2), inkl. `ci / gate success`.
- **Diff zielgerichtet:** neuer `gate`-Aggregat-Job · `runner-label-check` · ephemerer PG-Port (v1.0.5) · ephemere Git-Auth. Kein `deploy_runs_on`-artiger Bruch.

## Consumer-Contracts geprüft (alle erfüllt)

| Contract | learn-hub |
|----------|-----------|
| C1 `runner-label-check` (keine toten self-hosted-Pins) | ✅ keine Extra-Label-`runs-on`-Pins |
| C2 Test-Settings lesen `POSTGRES_PORT` | ✅ `config/settings/test.py:40` |
| C3 `runs_on`-Input | ✅ default `self-hosted` |

## Erwartung

PR triggert `ci.yml` → `ci / gate` muss **grün** erscheinen. Erst dann folgt der Eintrag in `platform/governance/rulesets/wave3-repos.json` + Protection-Apply.

> Folge-Notiz (nicht in diesem PR): `deploy.yml` ruft noch `@v1.0.2` — optionaler Konvergenz-Bump; doc-Banner Zeile 3 (`@main`) ist vorbestehender Kommentar-Drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)