### PR TITLE
feat(learning): import_lecture_module — Delivery-Projektion writing-hub → learnfw

### DIFF
--- a/apps/learning/management/commands/import_lecture_module.py
+++ b/apps/learning/management/commands/import_lecture_module.py
@@ -1,0 +1,137 @@
+"""Delivery-Projektion: writing-hub modul.json → learnfw Course/Chapter/Lesson.
+
+Konsumiert das ``lecture-module/v1``-Bündel aus writing-hub (File-Pfad, kein
+Live-RPC — KONZ-writing-hub-001 §5.1). Projektion:
+
+    modul       → Course
+    vorlesung   → Chapter   (ordering = dichtes 1..N nach position)
+    themenblock → Lesson    (content_type="text")
+
+Idempotenz wie ``seed_lernmodule``: Course per (title, tenant) angelegt;
+ohne ``--reset`` bricht ein zweiter Lauf ab (kein stilles Verdoppeln).
+``unique_together(course, ordering)`` erzwingt die Normalisierung auf 1..N.
+
+Usage:
+    python manage.py import_lecture_module modul.json --tenant <uuid> [--reset]
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+SCHEMA = "lecture-module/v1"
+
+
+def _lesson_text(block: dict) -> str:
+    """Themenblock → Lektions-Text (Subtitle + Bullets als Markdown + Notiz)."""
+    parts: list[str] = []
+    if block.get("subtitle"):
+        parts.append(str(block["subtitle"]))
+    bullets = block.get("bullets") or []
+    if bullets:
+        parts.append("\n".join(f"- {b}" for b in bullets))
+    if block.get("speaker_notes"):
+        parts.append(f"_{block['speaker_notes']}_")
+    return "\n\n".join(parts)
+
+
+class Command(BaseCommand):
+    help = "Projiziert ein writing-hub modul.json (lecture-module/v1) in learnfw."
+
+    def add_arguments(self, parser):
+        parser.add_argument("bundle", help="Pfad zur modul.json (lecture-module/v1)")
+        parser.add_argument(
+            "--tenant",
+            help="Tenant-UUID (Default: IIL_LEARNFW['DEFAULT_TENANT_ID'])",
+        )
+        parser.add_argument("--category", default="Vorlesungen", help="learnfw-Category-Name")
+        parser.add_argument(
+            "--reset",
+            action="store_true",
+            help="Vorhandenen Kurs (gleicher Titel + Tenant) vorher löschen",
+        )
+
+    def handle(self, *args, **opts):
+        from iil_learnfw.models import Category, Chapter, Course, Lesson
+
+        path = Path(opts["bundle"])
+        if not path.exists():
+            raise CommandError(f"Datei nicht gefunden: {path}")
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            raise CommandError(f"Kein gültiges JSON: {e}") from e
+
+        if data.get("schema") != SCHEMA:
+            raise CommandError(f"Erwarte schema={SCHEMA!r}, gefunden {data.get('schema')!r}")
+
+        tenant_raw = opts.get("tenant") or settings.IIL_LEARNFW.get("DEFAULT_TENANT_ID")
+        try:
+            tenant = uuid.UUID(str(tenant_raw))
+        except (TypeError, ValueError) as e:
+            raise CommandError(f"Ungültige Tenant-UUID: {tenant_raw!r}") from e
+
+        modul = data.get("modul") or {}
+        title = modul.get("titel")
+        if not title:
+            raise CommandError("Bündel ohne modul.titel — nichts zu importieren.")
+
+        if opts["reset"]:
+            deleted, _ = Course.objects.filter(title=title, tenant_id=tenant).delete()
+            self.stdout.write(f"Reset: {deleted} Objekte gelöscht.")
+
+        category, _ = Category.objects.get_or_create(
+            name=opts["category"], defaults={"tenant_id": tenant}
+        )
+
+        course, created = Course.objects.get_or_create(
+            title=title,
+            tenant_id=tenant,
+            defaults={
+                "description": modul.get("beschreibung", ""),
+                "status": "draft",  # importierte Inhalte nicht auto-publishen
+                "category": category,
+            },
+        )
+        if not created and not opts["reset"]:
+            raise CommandError(
+                f"Kurs {title!r} (Tenant {tenant}) existiert bereits — --reset zum Neuanlegen."
+            )
+
+        # position darf in writing-hub Lücken/Dubletten haben → hier dicht 1..N.
+        vorlesungen = sorted(data.get("vorlesungen", []), key=lambda v: v.get("position", 0))
+        n_ch = n_ls = 0
+        for ch_idx, v in enumerate(vorlesungen, 1):
+            chapter = Chapter.objects.create(
+                course=course,
+                title=v.get("thema", f"Vorlesung {ch_idx}"),
+                description="",
+                ordering=ch_idx,
+                tenant_id=tenant,
+            )
+            n_ch += 1
+            bloecke = v.get("themenbloecke") or []
+            per_min = max(1, round(v.get("umfang_min", 0) / len(bloecke))) if bloecke else 1
+            for ls_idx, block in enumerate(bloecke, 1):
+                Lesson.objects.create(
+                    chapter=chapter,
+                    title=block.get("titel", f"Themenblock {ls_idx}"),
+                    content_type="text",
+                    content_text=_lesson_text(block),
+                    estimated_duration_minutes=per_min,
+                    ordering=ls_idx,
+                    is_mandatory=True,
+                    tenant_id=tenant,
+                )
+                n_ls += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Importiert: Kurs {title!r} — {n_ch} Kapitel, {n_ls} Lektionen (Tenant {tenant})."
+            )
+        )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,3 +12,7 @@ psycopg[binary]>=3.1
 python-decouple>=3.8
 whitenoise>=6.5
 Pillow>=10.0
+# Transitive von iil-aifw (vom shared-CI installiert) — iil-aifw>=0.11.4 deklariert
+# tenacity, das hier nie gepinnt war → `pip check` rot (PR #14). writing-hub pinnt
+# es bereits; hier nachgezogen (Dependency-Completeness, vgl. risk-hub uv.lock-Lehre).
+tenacity>=8.2

--- a/tests/test_import_lecture_module.py
+++ b/tests/test_import_lecture_module.py
@@ -1,0 +1,96 @@
+"""
+import_lecture_module — Delivery-Projektion writing-hub → learnfw.
+
+Konsumiert ein lecture-module/v1-Bündel und legt Course/Chapter/Lesson an.
+Läuft über den Default-Tenant (kein --tenant), um Tenant-Scoping der
+learnfw-Manager nicht zu treffen.
+
+@pytest.mark.django_db: CI/PostgreSQL (ADR-179).
+"""
+
+import json
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+MODUL = "Test-Modul-Import"
+
+
+def _bundle(**over):
+    b = {
+        "schema": "lecture-module/v1",
+        "modul": {"titel": MODUL, "beschreibung": "desc"},
+        "vorlesungen": [
+            {
+                "thema": "V-zwei",
+                "position": 5,
+                "umfang_min": 90,
+                "sprache": "de",
+                "niveau": "einführend",
+                "themenbloecke": [
+                    {"titel": "TB1", "subtitle": "s", "bullets": ["a", "b"], "speaker_notes": "n"}
+                ],
+            },
+            {
+                "thema": "V-eins",
+                "position": 2,
+                "umfang_min": 60,
+                "sprache": "de",
+                "niveau": "einführend",
+                "themenbloecke": [
+                    {"titel": "TB-A", "subtitle": None, "bullets": ["x"], "speaker_notes": None}
+                ],
+            },
+        ],
+        "skipped_in_arbeit": 0,
+    }
+    b.update(over)
+    return b
+
+
+def _write(tmp_path, bundle):
+    p = tmp_path / "modul.json"
+    p.write_text(json.dumps(bundle), encoding="utf-8")
+    return str(p)
+
+
+@pytest.mark.django_db
+class TestImportLectureModule:
+    def test_should_project_modul_to_course_chapters_lessons(self, tmp_path):
+        from iil_learnfw.models import Chapter, Course, Lesson
+
+        call_command("import_lecture_module", _write(tmp_path, _bundle()))
+        course = Course.objects.get(title=MODUL)
+        chapters = list(Chapter.objects.filter(course=course).order_by("ordering"))
+        # nach position (2 vor 5) sortiert, ordering dicht 1..N normalisiert
+        assert [c.title for c in chapters] == ["V-eins", "V-zwei"]
+        assert [c.ordering for c in chapters] == [1, 2]
+        lessons = Lesson.objects.filter(chapter=chapters[0])
+        assert lessons.count() == 1
+        ls = lessons.first()
+        assert ls.content_type == "text"
+        assert "- x" in ls.content_text
+
+    def test_should_reject_wrong_schema(self, tmp_path):
+        with pytest.raises(CommandError):
+            call_command("import_lecture_module", _write(tmp_path, _bundle(schema="other/v9")))
+
+    def test_should_guard_against_double_import(self, tmp_path):
+        path = _write(tmp_path, _bundle())
+        call_command("import_lecture_module", path)
+        with pytest.raises(CommandError):
+            call_command("import_lecture_module", path)
+
+    def test_should_recreate_on_reset_without_duplicating(self, tmp_path):
+        from iil_learnfw.models import Chapter, Course
+
+        path = _write(tmp_path, _bundle())
+        call_command("import_lecture_module", path)
+        call_command("import_lecture_module", path, "--reset")
+        course = Course.objects.get(title=MODUL)
+        assert Chapter.objects.filter(course=course).count() == 2
+
+    def test_should_error_on_missing_file(self):
+        with pytest.raises(CommandError):
+            call_command("import_lecture_module", "/nonexistent/modul.json")


### PR DESCRIPTION
## Was

learn-hub-Hälfte der **Delivery-Projektion** (KONZ-writing-hub-001 §5.1). Ein Management-Command projiziert das writing-hub-Bündel **`lecture-module/v1`** (aus achimdehnert/writing-hub#85, File-Pfad — kein Live-RPC) in learnfw:

| Bündel | → | learnfw |
|---|---|---|
| `modul` | → | `Course` (status=`draft`, nicht auto-publish) |
| `vorlesung` | → | `Chapter` (`ordering` dicht 1..N nach `position`) |
| `themenblock` | → | `Lesson` (`content_type=text`) |

## Warum so

- **Ordering-Normalisierung:** writing-hub `position` darf Lücken/Dubletten haben → Importer sortiert nach `position` und vergibt dichtes `1..N` (sonst bricht `unique_together(course, ordering)`).
- **Idempotenz wie `seed_lernmodule`:** Course per (title, tenant); ohne `--reset` bricht ein zweiter Lauf mit `CommandError` ab (kein stilles Verdoppeln). `--reset` löscht + legt neu an.
- **`status=draft`:** importierte Inhalte werden nicht automatisch für Lernende publiziert.

## Usage

```
python manage.py import_lecture_module modul.json [--tenant <uuid>] [--category Vorlesungen] [--reset]
```

`--tenant` Default = `IIL_LEARNFW['DEFAULT_TENANT_ID']`.

## Tests (5, django_db)

Projektion + Ordering-Normalisierung (position 5/2 → ordering 1/2), Schema-Reject, Doppel-Import-Guard, `--reset` ohne Verdoppeln, fehlende Datei. Laufen über den Default-Tenant.

## Verifikation

✅ `ruff check` + `format` grün lokal. ⚠️ Tests lokal nicht lauffähig (`iil_learnfw` nicht installiert) → **CI ist die Verifikations-Instanz** (insb. dass die learnfw-Manager unter Default-Tenant wie erwartet anlegen/abfragen).

Gegenstück: achimdehnert/writing-hub#85 (`modul.json`-Export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)