### PR TITLE
feat(learning): Foliendeck als Lesson(content_type=pptx) projizieren

### DIFF
--- a/apps/learning/management/commands/import_lecture_module.py
+++ b/apps/learning/management/commands/import_lecture_module.py
@@ -6,6 +6,10 @@ Live-RPC — KONZ-writing-hub-001 §5.1). Projektion:
     modul       → Course
     vorlesung   → Chapter   (ordering = dichtes 1..N nach position)
     themenblock → Lesson    (content_type="text")
+    deck_url    → Lesson    (content_type="pptx", external_url=deck_url) ans
+                  Kapitel-Ende — optional; das Deck wird extern (pptx-hub)
+                  gerendert/gehostet, deck_url wird im Bündel manuell gefüllt
+                  (File-Pfad-v0). Fehlt/leer → kein Deck-Lesson.
 
 Idempotenz wie ``seed_lernmodule``: Course per (title, tenant) angelegt;
 ohne ``--reset`` bricht ein zweiter Lauf ab (kein stilles Verdoppeln).
@@ -125,6 +129,23 @@ class Command(BaseCommand):
                     content_text=_lesson_text(block),
                     estimated_duration_minutes=per_min,
                     ordering=ls_idx,
+                    is_mandatory=True,
+                    tenant_id=tenant,
+                )
+                n_ls += 1
+
+            # Foliendeck (pptx-hub-Render, extern via deck_url) → eigene
+            # Lesson(content_type=pptx) ans Kapitel-Ende. external_url, kein
+            # File-Upload (File-Pfad). Leer/fehlend → kein Deck-Lesson.
+            deck_url = (v.get("deck_url") or "").strip()
+            if deck_url:
+                Lesson.objects.create(
+                    chapter=chapter,
+                    title=f"Foliendeck: {v.get('thema', '')}".rstrip(": ") or "Foliendeck",
+                    content_type="pptx",
+                    external_url=deck_url,
+                    estimated_duration_minutes=max(1, v.get("umfang_min", 0) or 5),
+                    ordering=len(bloecke) + 1,
                     is_mandatory=True,
                     tenant_id=tenant,
                 )

--- a/tests/test_import_lecture_module.py
+++ b/tests/test_import_lecture_module.py
@@ -94,3 +94,28 @@ class TestImportLectureModule:
     def test_should_error_on_missing_file(self):
         with pytest.raises(CommandError):
             call_command("import_lecture_module", "/nonexistent/modul.json")
+
+    def test_should_project_deck_url_to_pptx_lesson(self, tmp_path):
+        from iil_learnfw.models import Chapter, Course, Lesson
+
+        bundle = _bundle()
+        bundle["vorlesungen"][0]["deck_url"] = "https://decks.example/v-zwei.pptx"
+        call_command("import_lecture_module", _write(tmp_path, bundle))
+        course = Course.objects.get(title=MODUL)
+        # V-zwei (position 5) → ordering 2; trägt das Deck
+        chapter = Chapter.objects.get(course=course, title="V-zwei")
+        deck = Lesson.objects.get(chapter=chapter, content_type="pptx")
+        assert deck.external_url == "https://decks.example/v-zwei.pptx"
+        assert deck.ordering == len(bundle["vorlesungen"][0]["themenbloecke"]) + 1
+        # andere Vorlesung ohne deck_url → kein pptx-Lesson
+        other = Chapter.objects.get(course=course, title="V-eins")
+        assert not Lesson.objects.filter(chapter=other, content_type="pptx").exists()
+
+    def test_should_skip_empty_deck_url(self, tmp_path):
+        from iil_learnfw.models import Course, Lesson
+
+        bundle = _bundle()
+        bundle["vorlesungen"][0]["deck_url"] = "  "  # leer/whitespace → kein Deck
+        call_command("import_lecture_module", _write(tmp_path, bundle))
+        course = Course.objects.get(title=MODUL)
+        assert not Lesson.objects.filter(chapter__course=course, content_type="pptx").exists()


### PR DESCRIPTION
## Was

Erweitert `import_lecture_module` um die **Deck-Ebene** (KONZ §5.1: *Vorlesung → Chapter + Deck als pptx-Lesson*). Optionales `deck_url` je Vorlesung im `lecture-module/v1`-Bündel wird zu einer `Lesson(content_type="pptx", external_url=deck_url)` ans Kapitel-Ende.

| Bündel-Feld | → | learnfw |
|---|---|---|
| `vorlesung.deck_url` (optional) | → | `Lesson(content_type="pptx", external_url=…)` |

## Warum so

- **`external_url`, kein File-Upload:** das Deck wird extern (pptx-hub) gerendert/gehostet; der Import referenziert es per URL (File-Pfad, kein Binär-Transfer). `content_type="pptx"` + `external_url` sind die dafür vorgesehenen learnfw-Felder.
- **Rückwärtskompatibel:** `deck_url` ist optional in `lecture-module/v1`; fehlt/leer → kein Deck-Lesson (kein Schema-Bump).
- **File-Pfad-v0:** writing-hub kann die Deck-URL (noch) nicht selbst liefern → `deck_url` wird im Bündel manuell gefüllt (writing-hub#86 emittiert den leeren Slot self-documenting).

## Tests (2 neu, django_db)

`deck_url` → pptx-Lesson mit `external_url` + korrektem `ordering` (Kapitel-Ende), andere Vorlesung ohne Deck bleibt deck-los; leeres/whitespace `deck_url` wird übersprungen.

## Verifikation

✅ `ruff` + `format` grün lokal. ⚠️ Tests lokal nicht lauffähig (iil-Deps) → **CI verifiziert**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)