### PR TITLE
fix(learnfw): Migration 0003_chapter_self_test + Drift-Gate (Prod-Incident)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,24 @@ jobs:
       django_settings_module: "config.settings.test"
       enable_security_scan: true
     secrets: inherit
+
+  # Drift-Gate: Modell vs. Migrations-Dateien. Die Unit-Tests laufen mit
+  # `--no-migrations` (Test-DB aus den Modellen) → eine FEHLENDE Migration ist
+  # dort unsichtbar, schlägt aber in Prod (`migrate`) zu (Incident
+  # Chapter.self_test, 2026-06-23). `makemigrations --check` (DB-frei) fängt das.
+  migration-drift:
+    name: "Migration Drift Gate"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: pip install -r requirements.txt -r requirements-test.txt
+      - name: makemigrations --check (Modell == Migrations-Dateien?)
+        env:
+          DJANGO_SETTINGS_MODULE: config.settings.test
+        run: |
+          python manage.py makemigrations --check --dry-run \
+            || { echo "::error::Modell-/Migrations-Drift — eine Migration fehlt. Lokal: python manage.py makemigrations"; exit 1; }

--- a/apps/learnfw_migrations/0003_chapter_self_test.py
+++ b/apps/learnfw_migrations/0003_chapter_self_test.py
@@ -1,0 +1,30 @@
+"""Fehlende Migration für ``Chapter.self_test`` (iil_learnfw 0.5.x).
+
+Das learnfw-Paket-Modell führte ``Chapter.self_test`` (JSONField) ein; learn-hub
+ist Migrations-Owner der Shared DB (MIGRATION_MODULES → apps.learnfw_migrations),
+aber die zugehörige Migration wurde nie generiert. Folge: Prod-DB ohne die Spalte
+→ jede Chapter-Operation bricht (``column ... self_test does not exist``). CI
+übersah es, weil Unit-Tests mit ``--no-migrations`` die Test-DB aus den Modellen
+bauen. Diese Migration schließt die Lücke; das neue makemigrations-Gate (ci.yml)
+verhindert die Wiederholung. Rein additiv, reversibel.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("iil_learnfw", "0002_assessment_engine"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="chapter",
+            name="self_test",
+            field=models.JSONField(
+                blank=True,
+                help_text='[{"question":"...","expected":"...","keywords":["k1"]}]',
+                null=True,
+            ),
+        ),
+    ]


### PR DESCRIPTION
## Prod-Incident (aufgedeckt durch den echten E2E der Modul→learnfw-Pipeline)

`learnfw` 0.5.x führte `Chapter.self_test` (JSONField) ein. learn-hub ist Migrations-Owner der Shared DB (`MIGRATION_MODULES → apps.learnfw_migrations`), aber **die Migration wurde nie generiert** → Prod-DB ohne die Spalte → **jede Chapter-Operation bricht** (`column iil_learnfw_chapter.self_test does not exist`), inkl. der Kapitel-Anzeige des realen „KI ohne Risiko™"-Kurses (1 Course, 9 Chapters).

### Verifizierte Root Cause (Hypothesen falsifiziert)
- **Nicht** Versions-Divergenz: CI **und** Prod ziehen `learnfw@main` (0.5.4) — belegt im CI-Klon-Log.
- **Nicht** per Pin behebbar: die Ursache ist Modell-vs-Migrations-Drift.
- **Warum CI grün war:** Unit-Tests laufen mit `--no-migrations` (Test-DB aus den **Modellen** gebaut → Spalte da). Es gab **kein** `makemigrations --check`-Gate → die fehlende Migration war unsichtbar. Prod baut per `migrate` aus den Dateien → Spalte fehlt.

## Fix

**A — Migration `0003_chapter_self_test`** — `AddField self_test JSONField(null=True, blank=True, help_text=…)`. Rein additiv, reversibel, kein Backfill. Nach Deploy + `migrate` ist Prod wieder heil.

**B — Drift-Gate (`ci.yml`)** — neuer Job `Migration Drift Gate`: `makemigrations --check --dry-run` (DB-frei). Fängt genau diese Klasse (Modell ohne Migration) künftig ab. Strukturell gehört das langfristig in shared-CI (alle Django-Repos) — hier zunächst learn-hub-lokal.

## Verifikation
- ✅ migration `py_compile`, ci.yml YAML valide (lokal).
- Das neue Gate **reproduziert** die Drift (ohne A wäre es rot) und **beweist** den Fix (mit A grün) — sichtbar im CI dieses PRs.
- ⚠️ Prod-`migrate` erst nach deinem Merge/Deploy-OK (Shared DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)