### PR TITLE
chore(deps): pin iil-learnfw @main → ==0.5.4 (Reproduzierbarkeit)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,11 @@ Django>=5.0,<6.0
 gunicorn>=22
 
 # IIL Platform Packages
-iil-learnfw[api] @ git+https://github.com/achimdehnert/learnfw.git@main
+# Pin auf immutables PyPI-Release statt @main — Build-Reproduzierbarkeit
+# (Audit-Finding #6). Der `@main`-Drift war der Nährboden des Chapter.self_test-
+# Incidents (2026-06-23): CI/Prod zogen unkontrolliert HEAD. 0.5.4 enthält
+# self_test (verifiziert) → konsistent mit Migration 0003. Bump bewusst per PR.
+iil-learnfw[api]==0.5.4
 iil-platform-context>=0.7.0,<1
 
 # Infrastructure


### PR DESCRIPTION
## Was

Pinnt `iil-learnfw` von `@ git+…@main` auf das immutable PyPI-Release **`==0.5.4`** — behebt **Audit-Finding #6** (nicht-reproduzierbarer Build).

## Warum

`@main` ließ CI *und* Prod unkontrolliert den jeweiligen HEAD ziehen — genau der Nährboden des `Chapter.self_test`-Incidents (2026-06-23). Ein immutables PyPI-Release macht Builds deterministisch und CI repräsentativ für Prod.

- **Verifiziert:** PyPI-sdist `iil-learnfw-0.5.4` enthält `self_test` in `models/course.py` → konsistent mit der gemergten Migration `0003_chapter_self_test`. Kein Schema-Bruch.
- `iil-platform-context` bleibt unverändert (bereits PyPI-Range).
- Bumps künftig **bewusst per PR** statt still bei jedem Build.

## Verifikation

- Das **Migration-Drift-Gate** (#16) läuft mit und bestätigt `0003` ↔ 0.5.4.
- CI sollte `iil-learnfw` jetzt **von PyPI** ziehen (kein git-clone) — im Build-Log prüfbar.

## Hinweis (separat, nicht in diesem PR)

learn-hubs Haupt-Checkout stand auf `chore/8-ruff-fix`; ich habe ihn auf `main` zurückgeschaltet. Der Branch hat 10 Commits, die **nicht** in `origin/main` sind (Inhalte scheinen über andere PRs gelandet) — **nicht gelöscht**, das ist deine Entscheidung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)