### PR TITLE
fix(learning): Lesson content_type text→markdown (out-of-enum bug)

### DIFF
--- a/apps/learning/management/commands/import_lecture_module.py
+++ b/apps/learning/management/commands/import_lecture_module.py
@@ -5,7 +5,7 @@ Live-RPC — KONZ-writing-hub-001 §5.1). Projektion:
 
     modul       → Course
     vorlesung   → Chapter   (ordering = dichtes 1..N nach position)
-    themenblock → Lesson    (content_type="text")
+    themenblock → Lesson    (content_type="markdown")
     deck_url    → Lesson    (content_type="pptx", external_url=deck_url) ans
                   Kapitel-Ende — optional; das Deck wird extern (pptx-hub)
                   gerendert/gehostet, deck_url wird im Bündel manuell gefüllt
@@ -125,7 +125,9 @@ class Command(BaseCommand):
                 Lesson.objects.create(
                     chapter=chapter,
                     title=block.get("titel", f"Themenblock {ls_idx}"),
-                    content_type="text",
+                    # "markdown" (gültiger learnfw-Choice); content_text IST Markdown.
+                    # "text" ist NICHT in CONTENT_TYPE_CHOICES → kein Render-Handler.
+                    content_type="markdown",
                     content_text=_lesson_text(block),
                     estimated_duration_minutes=per_min,
                     ordering=ls_idx,

--- a/apps/learning/management/commands/seed_lernmodule.py
+++ b/apps/learning/management/commands/seed_lernmodule.py
@@ -723,7 +723,7 @@ class Command(BaseCommand):
                 lesson = Lesson.objects.create(
                     chapter=chapter,
                     title=ls_data["title"],
-                    content_type="text",
+                    content_type="markdown",  # "text" ist kein gültiger learnfw-Choice
                     content_text=ls_data["content_text"],
                     estimated_duration_minutes=ls_data["estimated_duration_minutes"],
                     ordering=ls_idx,

--- a/tests/test_import_lecture_module.py
+++ b/tests/test_import_lecture_module.py
@@ -69,7 +69,10 @@ class TestImportLectureModule:
         lessons = Lesson.objects.filter(chapter=chapters[0])
         assert lessons.count() == 1
         ls = lessons.first()
-        assert ls.content_type == "text"
+        # gültiger learnfw-Choice (nicht das frühere out-of-enum "text")
+        valid = {c[0] for c in ls._meta.get_field("content_type").choices}
+        assert ls.content_type == "markdown"
+        assert ls.content_type in valid
         assert "- x" in ls.content_text
 
     def test_should_reject_wrong_schema(self, tmp_path):


### PR DESCRIPTION
Retro-Befund **D1** (2026-06-23, HIGH): `import_lecture_module` und `seed_lernmodule` schrieben `content_type="text"` — **kein gültiger learnfw-Choice** (markdown/pdf/pptx/external). Django-`choices` sind nicht DB-enforced → silent gespeichert, aber jeder Render-Dispatch findet keinen Handler (`markdown_backend` greift nur bei `"markdown"`). `content_text` IST Markdown → korrekt ist `"markdown"`.

- import_lecture_module.py: Themenblock-Lesson `text`→`markdown`
- seed_lernmodule.py: dito (seed_kurse nutzte bereits `markdown`)
- Test: prüft jetzt `content_type == "markdown"` UND `∈ field.choices`

**Folge (separat, Prod-Write):** bestehende Prod-Lessons mit `content_type="text"` per `UPDATE` nachziehen — read-only-Check + Fix nach Merge/Deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)