### PR TITLE
fix(learning): Lesson content_type "text" → "markdown" (out-of-enum Bug)

### DIFF
--- a/apps/learning/management/commands/import_lecture_module.py
+++ b/apps/learning/management/commands/import_lecture_module.py
@@ -5,7 +5,7 @@ Live-RPC — KONZ-writing-hub-001 §5.1). Projektion:
 
     modul       → Course
     vorlesung   → Chapter   (ordering = dichtes 1..N nach position)
-    themenblock → Lesson    (content_type="text")
+    themenblock → Lesson    (content_type="markdown")
     deck_url    → Lesson    (content_type="pptx", external_url=deck_url) ans
                   Kapitel-Ende — optional; das Deck wird extern (pptx-hub)
                   gerendert/gehostet, deck_url wird im Bündel manuell gefüllt
@@ -125,7 +125,9 @@ class Command(BaseCommand):
                 Lesson.objects.create(
                     chapter=chapter,
                     title=block.get("titel", f"Themenblock {ls_idx}"),
-                    content_type="text",
+                    # "markdown" (gültiger learnfw-Choice); content_text IST Markdown.
+                    # "text" ist NICHT in CONTENT_TYPE_CHOICES → kein Render-Handler.
+                    content_type="markdown",
                     content_text=_lesson_text(block),
                     estimated_duration_minutes=per_min,
                     ordering=ls_idx,

--- a/apps/learning/management/commands/seed_lernmodule.py
+++ b/apps/learning/management/commands/seed_lernmodule.py
@@ -723,7 +723,7 @@ class Command(BaseCommand):
                 lesson = Lesson.objects.create(
                     chapter=chapter,
                     title=ls_data["title"],
-                    content_type="text",
+                    content_type="markdown",  # "text" ist kein gültiger learnfw-Choice
                     content_text=ls_data["content_text"],
                     estimated_duration_minutes=ls_data["estimated_duration_minutes"],
                     ordering=ls_idx,

--- a/tests/test_import_lecture_module.py
+++ b/tests/test_import_lecture_module.py
@@ -69,7 +69,10 @@ class TestImportLectureModule:
         lessons = Lesson.objects.filter(chapter=chapters[0])
         assert lessons.count() == 1
         ls = lessons.first()
-        assert ls.content_type == "text"
+        # gültiger learnfw-Choice (nicht das frühere out-of-enum "text")
+        valid = {c[0] for c in ls._meta.get_field("content_type").choices}
+        assert ls.content_type == "markdown"
+        assert ls.content_type in valid
         assert "- x" in ls.content_text
 
     def test_should_reject_wrong_schema(self, tmp_path):


### PR DESCRIPTION
## Warum

`learnfw` `Lesson.content_type`-Choices sind **markdown / pdf / pptx / external** — **`"text"` ist NICHT dabei**. `import_lecture_module` und `seed_lernmodule` schrieben dennoch `content_type="text"` (silent, da Django-Choices nicht DB-enforced) → der Render-Dispatch findet **keinen Handler**, die Lesson rendert nicht. `content_text` IST Markdown → korrekt ist **`"markdown"`**. (`seed_kurse` war bereits korrekt.)

Retro-Befund **D1 (2026-06-23)**. Verwandt mit dem `Chapter.self_test`-Migrations-Incident (#16) und dem learnfw-Pin (#17) — gleiche Wurzel: learnfw-Contract nicht strikt eingehalten.

## Änderung

| Datei | Vorher | Nachher |
|---|---|---|
| `apps/learning/management/commands/import_lecture_module.py` | `content_type="text"` | `content_type="markdown"` (+ Begründungs-Kommentar) |
| `apps/learning/management/commands/seed_lernmodule.py` | `content_type="text"` | `content_type="markdown"` |
| `tests/test_import_lecture_module.py` | `assert == "text"` | `assert == "markdown"` **und** `content_type ∈ Field.choices` (Regression-Guard gegen erneutes Out-of-Enum) |

## Verifikation (lokal, ephemeral PG via `make test`)

- **`38 passed`** inkl. `test_should_project_modul_to_course_chapters_lessons`.
- Einzige Collection-Abweichung lokal: `tests/test_smoke_all_domains.py` braucht `requests` (nicht in den requirements; Live-Domain-Smoke) — **vorbestehend, von diesem Branch nicht berührt**, CI-Runner (self-hosted) hat `requests`; #15–#17 vom selben Base liefen grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)