### PR TITLE
test(deps): declare requests for live-domain smoke test

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,3 +5,4 @@ pytest-asyncio>=0.23
 ruff
 bandit
 iil-testkit>=0.1
+requests>=2.31  # tests/test_smoke_all_domains.py — Live-Domain-Smoke (HTTPS)


### PR DESCRIPTION
## Warum

`tests/test_smoke_all_domains.py` (tracked seit #9) importiert `requests` für Live-Domain-HTTPS-Smokes, aber **kein** requirements-File deklariert `requests`. In jeder Umgebung ohne global vorinstalliertes `requests` bricht pytest schon bei der **Collection** ab:

```
ImportError while importing test module 'tests/test_smoke_all_domains.py'
E   ModuleNotFoundError: No module named 'requests'
!!! Interrupted: 1 error during collection !!!
```

Bisher grün, **weil** der self-hosted CI-Runner `requests` global hat — eine versteckte Env-Abhängigkeit. Lokal (`make test` in frischem venv) reißt die ganze Suite ab.

## Änderung

`requirements/dev.txt`: `requests>=2.31` ergänzt (mit Kommentar auf den Konsumenten).

## Evidenz

Beim Verifizieren von #18/#19 reproduziert: der **einzige** Collection-Fehler war exakt dieser fehlende `requests`-Import; der Rest der Suite lief mit `38 passed` (nach `--ignore` dieser Datei). Diese Deklaration schließt genau die Lücke → Smoke-Test wird reproduzierbar (lokal + ephemere Runner), ohne sich auf vorinstallierte Runner-Pakete zu verlassen.

> Hinweis: Der Smoke-Test macht echte HTTPS-Calls gegen Prod-Domains — sinnvoll auf dem self-hosted Runner mit Netz; in netzlosen Umgebungen schlägt er fachlich (nicht mehr bei Collection) fehl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)