### PR TITLE
fix(compose): worker healthcheck → celery inspect ping (Fix false unhealthy)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,15 @@ services:
       redis: { condition: service_healthy }
       migrate: { condition: service_completed_successfully }
     restart: unless-stopped
+    # Override des Dockerfile-HEALTHCHECK (HTTP :8000/livez/ — nur für `web` korrekt).
+    # Der Worker fährt keinen HTTP-Server → der geerbte Check schlägt immer fehl
+    # (ConnectionRefused → false `unhealthy`). Celery-Liveness via `inspect ping`.
+    healthcheck:
+      test: ["CMD", "celery", "-A", "config.celery", "inspect", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     deploy:
       resources:
         limits: { memory: 384M }


### PR DESCRIPTION
## Symptom

`learn-hub-worker-1` steht in Prod (`docker ps`) als **`unhealthy`** — obwohl der Celery-Worker sauber läuft (`celery@… ready`, Redis verbunden, **0 Restarts**, verarbeitet Tasks).

## Root Cause

Der `HEALTHCHECK` ist im **`Dockerfile:30`** gebacken:

```dockerfile
HEALTHCHECK ... CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/livez/')"
```

Das ist korrekt für **`web`** (gunicorn auf :8000). Der **`worker`** nutzt dasselbe Image, fährt aber **keinen HTTP-Server** → jeder Probe-Lauf endet mit `ConnectionRefusedError [Errno 111]` → Container dauerhaft `unhealthy`. Der `worker:`-Service in `docker-compose.prod.yml` hatte **keinen** Healthcheck-Override.

Auswirkung heute: kosmetisch (kein Autoheal, `restart: unless-stopped` ignoriert Health) — aber verrauschtes Monitoring / falsches Alarmsignal.

## Fix (Variante A)

`worker`-Service bekommt einen eigenen Healthcheck, der **echte** Celery-Liveness prüft statt nur den falschen Check stummzuschalten:

```yaml
healthcheck:
  test: ["CMD", "celery", "-A", "config.celery", "inspect", "ping"]
  interval: 30s
  timeout: 10s
  retries: 3
  start_period: 20s
```

## Verifikation

- **Gegen den laufenden Prod-Worker** ausgeführt: `docker exec learn-hub-worker-1 celery -A config.celery inspect ping` → `pong`, `1 node online`, **exit 0**. Das ist exakt das Healthcheck-Kommando.
- `docker compose -f docker-compose.prod.yml config -q` → **valide** (gerenderter `worker.healthcheck` korrekt).

Nach Merge + Deploy sollte `learn-hub-worker-1` von `unhealthy` → `healthy` wechseln (binnen `interval`+`start_period`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)