### PR TITLE
[fix](compose): Postgres-Port 5499 an localhost binden (Audit C2)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,7 +53,7 @@ services:
     image: postgres:16-alpine
     env_file: .env.db
     ports:
-      - "5499:5432"
+      - "127.0.0.1:5499:5432"
     volumes:
       - learn_hub_data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
Platform-Audit 2026-07-04, Finding **C2 (Critical)**: `docker-compose.prod.yml` band Postgres auf `0.0.0.0:5499` — einziges von 27 Prod-Compose-Files der Flotte mit offenem DB-Port.

**Fix:** `127.0.0.1:5499:5432`.

**Vor Merge prüfen:** ob ein externer Consumer Port 5499 von außen nutzt (`ss -tnp | grep 5499` auf dem Host). Erwartung: nein.

Report: `platform/docs/audits/AUDIT-deployment-fleet-2026-07-04.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)