### PR TITLE
fix(ci): Caller-Job 'ci' ohne name-Override → required-Check 'ci / gate' (platform#811 Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
-# ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║  LEARN-HUB CI — Platform Reusable Workflow (ADR-057)                     ║
-# ║  Uses: achimdehnert/platform/.github/workflows/_ci-python.yml@main      ║
-# ╚═══════════════════════════════════════════════════════════════════════════╝
+# ╔════════════════════════════════════════════════════════════════════════════╗
+#║  LEARN-HUB CI — Platform Reusable Workflow (ADR-057)                     ║
+#║  Uses: achimdehnert/platform/.github/workflows/_ci-python.yml@main      ║
+# ╚════════════════════════════════════════════════════════════════════════════╝
 
 name: CI
 
@@ -12,7 +12,6 @@ on:
 
 jobs:
   ci:
-    name: "CI"
     uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.6
     with:
       python_version: "3.12"


### PR DESCRIPTION
## Was

Der Caller-Job `ci` in `.github/workflows/ci.yml` hatte `name: "CI"` → alle Checks erschienen als `CI / …`. Der ADR-242-Ruleset-Kontext für Wave 3 ist exakt-string `ci / gate` (lowercase) → matchte nie.

**Fix:** `name: "CI"` entfernt. Job-ID `ci` wird Display-Name → Checks erscheinen als `ci / gate`, `ci / lint`, … Einziger Variablen-Change; shared-ci-Ref bleibt `@v1.0.6` (hat den `gate`-Job mit `if: always()` seit v1.0.5). `migration-drift`-Job unverändert.

## Akzeptanz (platform#811 Phase 1)

- [ ] PR-Head emittiert exakt `ci / gate` (lowercase) und ist grün
- [ ] Kein anderer Check kaputt (`Migration Drift Gate` bleibt)
- [ ] Ergebnis (Check-Namen vom PR-Head) als Kommentar in platform#811

Closes #23 · Ref platform#811, ADR-242, ADR-209

🤖 Generated with [Claude Code](https://claude.com/claude-code)