### PR TITLE
fix(compose): restart: unless-stopped für web/db/redis (Prod-Recovery #958)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,7 @@ services:
     build: .
     image: ghcr.io/achimdehnert/learn-hub:latest
     env_file: .env.prod
+    restart: unless-stopped
     ports:
       - "127.0.0.1:8100:8000"
     depends_on:
@@ -52,6 +53,7 @@ services:
   db:
     image: postgres:16-alpine
     env_file: .env.db
+    restart: unless-stopped
     ports:
       - "127.0.0.1:5499:5432"
     volumes:
@@ -67,6 +69,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s


### PR DESCRIPTION
## Was
`web`, `db`, `redis` bekommen `restart: unless-stopped` (wie `worker` es schon hatte).

## Warum — Root Cause der ~64h P0-Downtime (achimdehnert/platform#958)
Beim Server-/Docker-Neustart am **2026-07-05** (Flächen-Outage: 15 Domains gleichzeitig 530/522) kamen alle Container **mit** Restart-Policy automatisch zurück → alle Nachbar-Hubs wieder 200. learn-hubs `web`/`db`/`redis` hatten **keine** Policy → blieben unten → nginx-Upstream `127.0.0.1:8100` ohne `web` → **502 an learn.iil.pet, ~64h durchgehend**. Der verwaiste `worker` (Policy vorhanden) lief weiter, konnte den nun fehlenden `redis` aber nicht mehr erreichen.

## Verifikation
- Prod bereits wiederhergestellt (`docker compose up -d` in `/opt/learn-hub`): learn.iil.pet /livez/, /healthz/, / = **200** über Cloudflare, migrate = *No migrations to apply*, worker *Connected to redis*.
- Live-Container zusätzlich sofort gehärtet via `docker update --restart unless-stopped` (Schutz bis zum nächsten Deploy).
- `migrate` bleibt bewusst **ohne** Policy (one-shot Job).

## Merge → Deploy (Owner-Gate)
Merge löst `Deploy` aus (push→main) und rekonziliert nebenbei den Server-Compose-Drift (live läuft noch pre-#24 mit `0.0.0.0:5499`; main hat bereits `127.0.0.1:5499`).

Refs achimdehnert/platform#958

🤖 Generated with [Claude Code](https://claude.com/claude-code)