### PR TITLE
fix(ci): _deploy-unified auf shared-ci@v1.0.10 (scp-action composite)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
   deploy:
     needs: [ci]
     if: always() && (needs.ci.result == 'success' || needs.ci.result == 'skipped')
-    uses: iilgmbh/shared-ci/.github/workflows/_deploy-unified.yml@v1.0.2
+    uses: iilgmbh/shared-ci/.github/workflows/_deploy-unified.yml@v1.0.10
     with:
       app_name: "learn-hub"
       app_path: "/opt/learn-hub"


### PR DESCRIPTION
## Problem
Docker-Actions werden von GitHub **beim Job-Setup gebaut**, auch wenn ihr Step per `if:` übersprungen wird. `appleboy/scp-action@v0.1.7` ist eine Docker-Action und baut dabei ein Image `FROM ghcr.io/appleboy/drone-scp:1.6.14`. Auf **self-hosted** Runnern mit (abgelaufenen) `ghcr.io`-Credentials in der Docker-Config scheitert dieser Pull mit `denied` — der Job stirbt **vor dem ersten Step**.

Dieses Repo ist betroffen: `deploy_runs_on: prod-server`.

Belegt an travel-beat: [run 29090717744](https://github.com/achimdehnert/travel-beat/actions/runs/29090717744) (rot, `v0.1.7`) → nach dem Bump [run 29099432399](https://github.com/achimdehnert/travel-beat/actions/runs/29099432399) (`deploy / 🚀 Production` **success**). Das Basis-Image selbst ist öffentlich (anonymer Manifest-Abruf: HTTP 200).

## Fix
[iilgmbh/shared-ci#22](https://github.com/iilgmbh/shared-ci/pull/22) ersetzt `scp-action@v0.1.7` durch `@v1.0.0` (composite → kein Image-Build → keine GHCR-Abhängigkeit). Enthalten ab Tag **v1.0.10**.

Nur `_deploy-unified.yml` wird gebumpt; andere shared-ci-Refs bleiben unverändert.

## Kompatibilität (geprüft)
Signatur-Diff `_deploy-unified.yml` (YAML-Parse beider Refs, gegen die älteste betroffene Version `v1.0.2`): keine neuen Pflicht-Inputs, keine entfernten Inputs, keine geänderten Pflicht-Secrets. `secrets: inherit` unverändert.

## Scope
Von 23 shared-ci-Consumern laufen nur 4 auf self-hosted Runnern. Die 16 GitHub-hosted Repos sind **nicht** betroffen (dort greift der anonyme GHCR-Pull) und werden bewusst nicht gebumpt, um unnötige Prod-Deploys zu vermeiden.

## Test plan
- [x] YAML validiert.
- [x] Canary travel-beat: Prod-Deploy nach Bump grün, `atomic sync complete (self-hosted)`, Health 200.
- [ ] **Merge löst einen Produktions-Deploy dieses Repos aus** — der Run ist der eigentliche Beweis.

⚠️ Merge triggert Prod-Deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)